### PR TITLE
[Bugfix] Wrong passing params when using magic __call

### DIFF
--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -374,11 +374,7 @@ class Cpanel implements CpanelInterface
         ]);
 
         $response = $this->runQuery($action, $params);
-        if (!empty($response['cpanelresult'])) {
-            return $response['cpanelresult']['data'];
-        } else {
-            throw new \Exception($response['error']);
-        }
+        return $response;
     }
 
     /**

--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -54,6 +54,20 @@ class Cpanel implements CpanelInterface
     protected $headers = array();
 
     /**
+     * @var integer Query timeout (Guzzle option)
+     *
+     * @since v1.0.0
+     */
+    protected $timeout = 10;
+
+    /**
+     * @var integer Connection timeout (Guzzle option)
+     *
+     * @since v1.0.0
+     */
+    protected $connection_timeout = 2;
+
+    /**
      * Class constructor. The options must be contain username, host, and password.
      *
      * @param array $options options that will be passed and processed
@@ -182,6 +196,38 @@ class Cpanel implements CpanelInterface
     }
 
     /**
+     * set timeout.
+     *
+     * @param $timeout
+     *
+     * @return object return as self-object
+     *
+     * @since v1.0.0
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = (int) $timeout;
+
+        return $this;
+    }
+
+    /**
+     * set connection timeout.
+     *
+     * @param $connection_timeout
+     *
+     * @return object return as self-object
+     *
+     * @since v1.0.0
+     */
+    public function setConnectionTimeout($connection_timeout)
+    {
+        $this->connection_timeout = (int) $connection_timeout;
+
+        return $this;
+    }
+
+    /**
      * get username.
      *
      * @return string return username
@@ -230,6 +276,30 @@ class Cpanel implements CpanelInterface
     }
 
     /**
+     * get timeout.
+     *
+     * @return integer timeout of the Guzzle request
+     *
+     * @since v1.0.0
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * get connection timeout.
+     *
+     * @return integer connection timeout of the Guzzle request
+     *
+     * @since v1.0.0
+     */
+    public function getConnectionTimeout()
+    {
+        return $this->connection_timeout;
+    }
+
+    /**
      * Extend HTTP headers that will be sent.
      *
      * @return array list of headers that will be sent
@@ -271,8 +341,8 @@ class Cpanel implements CpanelInterface
               // 'body'    => $arguments[0],
               'verify' => false,
               'query' => $arguments[0],
-              'timeout' => 10,
-              'connect_timeout' => 2
+              'timeout' => $this->getTimeout(),
+              'connect_timeout' => $this->getConnectionTimeout()
           ]);
 
           return (string) $response->getBody();

--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -398,21 +398,7 @@ class Cpanel implements CpanelInterface
             'cpanel_jsonapi_user' => $username,
         ]);
         $response = $this->runQuery($action, $params);
-        if (!empty($response['data']) && empty($response['error'])) {
-            return $response['data'];
-        } elseif (!empty($response['cpanelresult']) && empty($response['cpanelresult']['error'])) {
-            return $response['cpanelresult']['data'];
-        } elseif (!empty($response['cpanelresult']) && !empty($response['cpanelresult']['error'])) {
-            throw new \Exception($response['cpanelresult']['error']);
-        } elseif(!empty($response['result']) && $response['result']['errors'] == NULL) {
-            return $response['result']['data'];
-        } elseif(!empty($response['result']) && $response['result']['errors'] != NULL) {
-            foreach ($response['result']['errors'] as $error){
-                $error = $error.' ';
-            }
-            throw new \Exception($error);
-        } else {
-            throw new \Exception($response['error']);
-        }
+        
+        return $response;
     }
 }

--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -270,7 +270,7 @@ class Cpanel implements CpanelInterface
               'headers' => $this->createHeader(),
               // 'body'    => $arguments[0],
               'verify' => false,
-              'query' => $arguments,
+              'query' => $arguments[0],
               'timeout' => 10,
               'connect_timeout' => 2
           ]);

--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -340,7 +340,7 @@ class Cpanel implements CpanelInterface
               'headers' => $this->createHeader(),
               // 'body'    => $arguments[0],
               'verify' => false,
-              'query' => $arguments[0],
+              'query' => count($arguments) > 1 ? $arguments : $arguments[0],
               'timeout' => $this->getTimeout(),
               'connect_timeout' => $this->getConnectionTimeout()
           ]);

--- a/src/Gufy/CpanelPhp/CpanelShortcuts.php
+++ b/src/Gufy/CpanelPhp/CpanelShortcuts.php
@@ -31,12 +31,12 @@ trait cPanelShortcuts
      */
     public function createAccount($domain_name, $username, $password, $plan)
     {
-        return $this->runQuery('createacct', [
+        return $this->runQuery('createacct', [[
             'username' => $username,
             'domain' => $domain_name,
             'password' => $password,
             'plan' => $plan,
-        ]);
+        ]]);
     }
 
     /**
@@ -46,9 +46,9 @@ trait cPanelShortcuts
      */
     public function destroyAccount($username)
     {
-        return $this->runQuery('removeacct', [
+        return $this->runQuery('removeacct', [[
             'username' => $username,
-        ]);
+        ]]);
     }
 
     /**


### PR DESCRIPTION
When you call an api method directly (like createacct) you have to pass an associative array with (keys and values). But the magic __call method convert them to multiple argument array without the keys and it's impossible to use them (the only way is to use the shortcut methods, but they are not completed).
I changed the passing arguments to the Guzzle request and edit the shortcut methods to pass single-segment array with associative array of params.