### PR TITLE
Standardize the trait name

### DIFF
--- a/src/Gufy/CpanelPhp/CpanelShortcuts.php
+++ b/src/Gufy/CpanelPhp/CpanelShortcuts.php
@@ -1,13 +1,13 @@
 <?php namespace Gufy\CpanelPhp;
 
 /**
- * Trait cPanelShortcuts
+ * Trait CpanelShortcuts
  *
  * A handful of shortcuts for getting things done(tm)
  *
  * @package Gufy\CpanelWhm
  */
-trait cPanelShortcuts
+trait CpanelShortcuts
 {
     /**
      * List all the accounts that the reseller has access to.


### PR DESCRIPTION
Hello! I know it maybe not a problem in itself since php class is case insensitive, but can we have the trait name standardised? I'm getting an error using it within the context of symfony framework because they are checking for the case difference. Please let me know what you think. Thanks!