### PR TITLE
Fix uncaught GuzzleHttp Exceptions

### DIFF
--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -347,9 +347,9 @@ class Cpanel implements CpanelInterface
 
           return (string) $response->getBody();
         }
-        catch(\GuzzleHttp\Exceptions\ClientException $e)
+        catch(\GuzzleHttp\Exception\ClientException $e)
         {
-          return $e->getResponse()->json();
+          return $e->getMessage();
         }
     }
 


### PR DESCRIPTION
Exceptions aren't caught in case of e.g. an authentication failure because:

- typo in exception class?
- `$e->getResponse()->json()` method doesn't exist