### PR TITLE
Fix mgufrone/cpanel-php#11

### DIFF
--- a/src/Gufy/CpanelPhp/Cpanel.php
+++ b/src/Gufy/CpanelPhp/Cpanel.php
@@ -98,8 +98,10 @@ class Cpanel implements CpanelInterface
      *
      * @since v1.0.0
      */
-    public function __call($function, $arguments = [])
+    public function __call($function, $arguments)
     {
+        if (count($arguments) > 0)
+            $arguments = $arguments[0];
         return $this->runQuery($function, $arguments);
     }
 


### PR DESCRIPTION
$argument is enumerated array containing the parameters passed to the method.
As far as I know, only one argument is expected here (an array of parameters to pass to the API function) so we can safely use `$arguments[0]`.