### PR TITLE
Include the 'listforwards' API command

### DIFF
--- a/src/Gufy/CpanelPhp/CpanelShortcuts.php
+++ b/src/Gufy/CpanelPhp/CpanelShortcuts.php
@@ -60,6 +60,16 @@ trait CpanelShortcuts
     {
         return $this->cpanel('Email', 'listpops', $username);
     }
+    
+    /**
+     * Gets the forwarders that exist under a cPanel account
+     *
+     * @param $username
+     */
+    public function listForwards($username)
+    {
+        return $this->cpanel('Email', 'listforwards', $username);
+    }
 
     /**
      * @param $username **cPanel username**


### PR DESCRIPTION
Addition to allow extraction of all the cPanel forwarders configured for this account.

Typical `json` decoded format for this output is:

```stdClass Object
(
    [cpanelresult] => stdClass Object
        (
            [data] => Array
                (
                    [0] => stdClass Object
                        (
                            [dest] => from_where@domain.com
                            [html_dest] => from_where@domain.com
                            [uri_dest] => from_where%40domain.com
                            [forward] => to_where@domain.com
                            [html_forward] => to_where@domain.com
                            [uri_forward] => to_where%40domain.com
                        )
...
```